### PR TITLE
Create dissappearing messages, as well as SongQueueMessages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,11 @@ import { Client, Command } from './src/types.js';
 import Enmap from 'enmap';
 import './src/local-data.js';
 
+// Remove this
+process.on('unhandledRejection', error => {
+    console.error('Unhandled promise rejection:', error);
+});
+
 async function load(client: Client) {
     let utils = (await import('./src/utils')).default;
     let config = (await import('./config')).default;

--- a/src/commands/playlist.ts
+++ b/src/commands/playlist.ts
@@ -67,7 +67,7 @@ export const run = async (client: Client, message: Message, args: Array<string>)
                 if (playlist.length === config.playlists.maximumItemsPerPlaylist)
                     return message.channel.send({ embeds: [embeds.errorEmbed().setDescription(`Playlist has reached maximum number of items`)] });
 
-                songs.forEach(async x => localData.addSong(userId, playlistName, (await x.song).url));
+                songs.forEach(async x => localData.addSong(userId, playlistName, x.song.url));
                 message.channel.send({ embeds: [embeds.defaultEmbed().setDescription(`Added ${songs.length} song(s) to playlist`)] });
                 break;
             }
@@ -75,12 +75,12 @@ export const run = async (client: Client, message: Message, args: Array<string>)
                 if (!hasPlaylist) return message.channel.send({ embeds: [embeds.errorEmbed().setDescription(`No such playlist exists`)] });
                 if (!songs.length) return message.channel.send({ embeds: [embeds.errorEmbed().setDescription(`Not a valid song(s)`)] });
 
-                let occurences = await [...new Set(songs)]
-                    .map(async x => localData.hasSong(userId, playlistName, (await x.song).url) ? 1 : 0)
-                    .reduce(async (prev, current) => (await prev) + (await current));
+                let occurences = [...new Set(songs)]
+                    .map(x => localData.hasSong(userId, playlistName, x.song.url) ? 1 : 0)
+                    .reduce((prev, current) => prev + current);
                 if (occurences === 0) return message.channel.send({ embeds: [embeds.defaultEmbed().setDescription('Song(s) not found in playlist')] });
 
-                songs.forEach(async x => localData.removeSong(userId, playlistName, (await x.song).url));
+                songs.forEach(async x => localData.removeSong(userId, playlistName, x.song.url));
                 message.channel.send({ embeds: [embeds.defaultEmbed().setDescription(`Removed ${occurences} song(s) from playlist`)] });
 
                 break;

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -82,13 +82,12 @@ export const run = async (client: Client, message: Message, args: Array<string>)
                 page = ROW_BTN_FUNC[i](page, maxPages);
                 let content = await getQueueContent(page, serverQueue, maxPages);
                 await interaction.update({ content });
-                // interaction.reply(ROW_BTN_LABELS[i]);
                 return;
             }
     });
 
     utils.log('Showed music queue');
-    return message.channel.send({
+    return serverQueue.messages.get('queue')?.send(message.channel, {
         content: queuetxt,
         components: [row]
     });

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -16,7 +16,7 @@ const ROW_BTN_FUNC = [
     (page: number, maxPages: number) => maxPages - 1
 ];
 
-async function getQueueContent(page: number, serverQueue: ServerQueue, maxPages: number) {
+function getQueueContent(page: number, serverQueue: ServerQueue, maxPages: number) {
     page = Math.max(0, Math.min(page, maxPages - 1));
 
     let queuetxt = '```swift';
@@ -26,7 +26,7 @@ async function getQueueContent(page: number, serverQueue: ServerQueue, maxPages:
     let endIndex = Math.min((page + 1) * PAGE_SIZE, serverQueue.songs.length);
     for (let i = page * PAGE_SIZE; i < endIndex; i++) {
         let songReference = serverQueue.songs[i];
-        let song = await songReference.song;
+        let song = songReference.song;
         let indexStr = (i + 1)
             .toString()
             .padStart(Math.floor(Math.log10(endIndex)) + 1, ' ');
@@ -66,7 +66,7 @@ export const run = async (client: Client, message: Message, args: Array<string>)
     }
     page = Math.max(0, Math.min(page, maxPages - 1));
 
-    let queuetxt = await getQueueContent(page, serverQueue, maxPages);
+    let queuetxt = getQueueContent(page, serverQueue, maxPages);
 
     const row = new MessageActionRow();
     row.addComponents(...ROW_BTN_EMOJI.map(emoji => new MessageButton()
@@ -86,7 +86,7 @@ export const run = async (client: Client, message: Message, args: Array<string>)
             for (let i = 0; i < ROW_BTN_EMOJI.length; i++)
                 if (interaction.customId === ROW_BTN_EMOJI[i]) {
                     page = ROW_BTN_FUNC[i](page, maxPages);
-                    let content = await getQueueContent(page, serverQueue, maxPages);
+                    let content = getQueueContent(page, serverQueue, maxPages);
                     await interaction.update({ content })
                         .catch(console.error);
                     return;

--- a/src/commands/skip.ts
+++ b/src/commands/skip.ts
@@ -13,10 +13,10 @@ import { Client, Message } from 'discord.js';
  */
 export const run = async (client: Client, message: Message, args: Array<string>) => {
     const serverQueue = queueManager.get(message.guild!.id)!;
-    utils.log(`Skipped music : ${(await serverQueue!.songs[0].song).title}`);
+    utils.log(`Skipped music : ${serverQueue!.songs[0].song.title}`);
     serverQueue!.skip();
 
-    const currentSong = await serverQueue.currentSong();
+    const currentSong = serverQueue.currentSong();
     if (currentSong)
         return message.channel.send({ embeds: [embeds.songEmbed(currentSong, 'Skipping', false)] });
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,65 @@
+import { Collection, Message, MessageOptions, MessagePayload } from 'discord.js';
+
+class CustomMessage {
+    protected message: Message<boolean> | undefined;
+    constructor() {
+        this.message = undefined;
+    }
+
+    async _send(channel: Message['channel'], options: string | MessagePayload | MessageOptions) {
+        this.message = await channel.send(options);
+        return this.message;
+    }
+
+    async send(channel: Message['channel'], options: string | MessagePayload | MessageOptions) {
+        this._send(channel, options);
+        return this.message;
+    }
+}
+
+/**
+ * When a new message is sent, delete the previous one
+ */
+export class SingletonMessage extends CustomMessage {
+    constructor() {
+        super();
+    }
+
+    async send(channel: Message['channel'], options: string | MessagePayload | MessageOptions) {
+        if (this.message) this.message.delete().catch(err => console.log(err));
+        return await this._send(channel, options);
+    }
+}
+
+export class SongQueueMessage extends CustomMessage {
+    constructor() {
+        super();
+    }
+
+    // Disable buttons for the previous song queue message
+    async disableButtons() {
+        if (!this.message) return;
+
+        this.message.components[0].components.forEach(
+            button => button.setDisabled(true)
+        );
+
+        this.message.edit({ components: this.message.components }).catch(console.error);
+    }
+
+    async send(channel: Message['channel'], options: string | MessagePayload | MessageOptions) {
+        // TODO: Figure out why DiscordAPIError is thrown.
+        // We send a new message, and disable the buttons on the previous message
+        let message = this._send(channel, options);
+        await this.disableButtons();
+        return message;
+    }
+}
+
+class MessageCollection extends Collection<string, SingletonMessage | SongQueueMessage> {
+    constructor() {
+        super();
+    }
+}
+
+export default MessageCollection;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -32,25 +32,27 @@ export class SingletonMessage extends CustomMessage {
 }
 
 export class SongQueueMessage extends CustomMessage {
+    private previousMessage: Message<boolean> | undefined;
     constructor() {
         super();
     }
 
     // Disable buttons for the previous song queue message
     async disableButtons() {
-        if (!this.message) return;
+        if (!this.previousMessage) return;
 
-        this.message.components[0].components.forEach(
+        this.previousMessage.components[0].components.forEach(
             button => button.setDisabled(true)
         );
 
-        this.message.edit({ components: this.message.components }).catch(console.error);
+        this.previousMessage.edit({ components: this.previousMessage.components }).catch(console.error);
     }
 
     async send(channel: Message['channel'], options: string | MessagePayload | MessageOptions) {
         // TODO: Figure out why DiscordAPIError is thrown.
         // We send a new message, and disable the buttons on the previous message
-        let message = this._send(channel, options);
+        this.previousMessage = this.message;
+        let message = await this._send(channel, options);
         await this.disableButtons();
         return message;
     }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -107,7 +107,7 @@ export class ServerQueue {
     }
 
     async sendNowPlayingEmbed(song: Song) {
-        this.messages.get('nowPlaying')?.send(song.requestedChannel, { embeds: [embeds.songEmbed(song, 'Now Playing')] })
+        this.messages.get('nowPlaying')?.send(song.requestedChannel, { embeds: [embeds.songEmbed(song, 'Now Playing')] });
     }
 
     /**
@@ -117,7 +117,7 @@ export class ServerQueue {
      * @return {number} Validated seek time
      */
     async seekTo(seekTime: number, errorCounter = 0) {
-        const song = await this.currentSong()!;
+        const song = this.currentSong()!;
 
         seekTime = Math.max(0, seekTime);
         seekTime = Math.min(song.duration, seekTime);
@@ -149,7 +149,7 @@ export class ServerQueue {
         }
 
         if (this.songs[this.index + 1])
-            utils.log(`Finished playing the music : ${(await this.songs[this.index].song).title}`);
+            utils.log(`Finished playing the music : ${(this.songs[this.index].song).title}`);
         else
             utils.log(`Finished playing all musics, no more musics in the queue`);
 
@@ -196,7 +196,7 @@ export class ServerQueue {
 
         this.shuffled = false;
 
-        const song = await this.currentSong()!;
+        const song = this.currentSong()!;
         this.textChannel = song.requestedChannel; // Update text channel
         this._isPlaying = true;
 

--- a/src/song.ts
+++ b/src/song.ts
@@ -259,7 +259,7 @@ class YouTubeSong extends Song {
                     message.channel
                 );
             } else
-                songReference = await SongManager.getSongReference(id, message.author, message.channel);
+                songReference = SongManager.getSongReference(id, message.author, message.channel);
 
             songs.push(songReference);
         }
@@ -381,18 +381,18 @@ export class SongManager {
 
         SongManager.checkCleanup();
 
-        return await this.getSongReference(song.id, requestedBy, requestedChannel);
+        return this.getSongReference(song.id, requestedBy, requestedChannel);
     }
 
-    static async getSong(id: string): Promise<YouTubeSong | FileSong> {
+    static getSong(id: string): YouTubeSong | FileSong {
         let song = SongManager.songs.get(id);
         if (typeof song === 'undefined') throw new SongNotFoundError();
 
         return song;
     }
 
-    static async getSongReference(id: string, requestedBy: User, requestedChannel: Message['channel']) {
-        let song = await SongManager.getSong(id);
+    static getSongReference(id: string, requestedBy: User, requestedChannel: Message['channel']) {
+        let song = SongManager.getSong(id);
         if (typeof song === 'undefined') throw new SongNotFoundError(); // need to change to throw error
 
         return new SongReference(song.id, requestedBy, requestedChannel);


### PR DESCRIPTION
Disappearing messages are used for the now playing embed while the latter is used to disable buttons once a new queue is displayed in a text channel.

We'll need to improve the queue looping command as the keys in the LOOP_MODES enum in src/queue.ts must be uppercase due to code styling spec.