### PR TITLE
Rewrite messages

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -16,6 +16,12 @@ class CustomMessage {
         await this._send(channel, options);
         return this.message;
     }
+
+    async delete() {
+        let deletedMessage = await this.message?.delete().catch(err => console.log(err));
+        this.message = undefined;
+        return deletedMessage;
+    }
 }
 
 export class NormalMessage extends CustomMessage {
@@ -33,7 +39,7 @@ export class SingletonMessage extends CustomMessage {
     }
 
     async send(channel: TextLikeChannels, options: string | MessagePayload | MessageOptions) {
-        if (this.message) this.message.delete().catch(err => console.log(err));
+        await this.delete();
         return await this._send(channel, options);
     }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -46,19 +46,22 @@ export class SingletonMessage extends CustomMessage {
 
 export class SongQueueMessage extends CustomMessage {
     private previousMessage: Message<boolean> | undefined;
+    private active: boolean; // Buttons active?
     constructor() {
         super();
+        this.active = false;
     }
 
     // Disable buttons for the previous song queue message
     async disableButtons() {
-        if (!this.previousMessage) return;
+        if (!this.previousMessage || !this.active) return;
 
         this.previousMessage.components[0].components.forEach(
             button => button.setDisabled(true)
         );
 
         this.previousMessage.edit({ components: this.previousMessage.components }).catch(console.error);
+        this.active = false;
     }
 
     async send(channel: TextLikeChannels, options: string | MessagePayload | MessageOptions) {
@@ -66,6 +69,7 @@ export class SongQueueMessage extends CustomMessage {
         // We send a new message, and disable the buttons on the previous message
         this.previousMessage = this.message;
         let message = await this._send(channel, options);
+        if (message) this.active = true;
         await this.disableButtons();
         return message;
     }

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -389,6 +389,7 @@ export class ServerQueue {
      */
     leave() {
         this.connection?.destroy();
+        (this.messages.get('queue') as SongQueueMessage).disableButtons();
         this.clear(true);
     }
 }

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -214,6 +214,7 @@ export class ServerQueue {
         } else {
             log(`Finished playing all musics, no more musics in the queue`);
             await this.messages.get('finishedPlaying')?.send(this.textChannel, { embeds: [songEmbed(this.currentSong(), 'Finished Playing')] });
+            await this.messages.get('nowPlaying')?.delete();
         }
     }
 


### PR DESCRIPTION
Typescript doesn't know what type each of the messages are in the hashmap so I had to explicitly define SongQueueMessage's type. https://github.com/hellomouse/Destiny/blob/5af3410d0d87ef8934964484e9385c730acdc092/src/queue/queue.ts#L392

The queue command will disable buttons for the previous message like before but the bot leaving the Voice Channel and ServerQueue being destroyed will do the same.

Should anything else be done?